### PR TITLE
Add custom countvectorizer

### DIFF
--- a/keybert/__init__.py
+++ b/keybert/__init__.py
@@ -1,1 +1,2 @@
 from keybert.model import KeyBERT
+__version__ = "0.1.3"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="keybert",
     packages=["keybert"],
-    version="0.1.2",
+    version="0.1.3",
     author="Maarten Grootendorst",
     author_email="maartengrootendorst@gmail.com",
     description="KeyBERT performs keyword extraction with state-of-the-art transformer models.",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,47 +1,56 @@
 import pytest
 from .utils import get_test_data
+from sklearn.feature_extraction.text import CountVectorizer
 
 doc_one, doc_two = get_test_data()
 
 
-@pytest.mark.parametrize("keyphrase_length", [i+1 for i in range(5)])
-def test_single_doc(keyphrase_length, base_keybert):
+@pytest.mark.parametrize("keyphrase_length", [(1, i+1) for i in range(5)])
+@pytest.mark.parametrize("vectorizer", [None, CountVectorizer(ngram_range=(1, 1), stop_words="english")])
+def test_single_doc(keyphrase_length, vectorizer, base_keybert):
     """ Test whether the keywords are correctly extracted """
     top_n = 5
-    keywords = base_keybert.extract_keywords(doc_one, keyphrase_length=keyphrase_length, min_df=1, top_n=top_n)
+
+    keywords = base_keybert.extract_keywords(doc_one,
+                                             keyphrase_ngram_range=keyphrase_length,
+                                             min_df=1,
+                                             top_n=top_n,
+                                             vectorizer=vectorizer)
     assert isinstance(keywords, list)
     assert isinstance(keywords[0], str)
     assert len(keywords) == top_n
     for keyword in keywords:
-        assert len(keyword.split(" ")) == keyphrase_length
+        assert len(keyword.split(" ")) <= keyphrase_length[1]
 
 
-@pytest.mark.parametrize("keyphrase_length, mmr, maxsum", [(i+1, truth, not truth)
+@pytest.mark.parametrize("keyphrase_length, mmr, maxsum", [((1, i+1), truth, not truth)
                                                            for i in range(4)
                                                            for truth in [True, False]])
-def test_extract_keywords_single_doc(keyphrase_length, mmr, maxsum, base_keybert):
+@pytest.mark.parametrize("vectorizer", [None, CountVectorizer(ngram_range=(1, 1), stop_words="english")])
+def test_extract_keywords_single_doc(keyphrase_length, mmr, maxsum, vectorizer, base_keybert):
     """ Test extraction of protected single document method """
     top_n = 5
     keywords = base_keybert._extract_keywords_single_doc(doc_one,
                                                          top_n=top_n,
-                                                         keyphrase_length=keyphrase_length,
+                                                         keyphrase_ngram_range=keyphrase_length,
                                                          use_mmr=mmr,
                                                          use_maxsum=maxsum,
-                                                         diversity=0.5)
+                                                         diversity=0.5,
+                                                         vectorizer=vectorizer)
     assert isinstance(keywords, list)
     assert isinstance(keywords[0], str)
     assert len(keywords) == top_n
     for keyword in keywords:
-        assert len(keyword.split(" ")) == keyphrase_length
+        assert len(keyword.split(" ")) <= keyphrase_length[1]
 
 
-@pytest.mark.parametrize("keyphrase_length", [i+1 for i in range(5)])
+@pytest.mark.parametrize("keyphrase_length", [(1, i+1) for i in range(5)])
 def test_extract_keywords_multiple_docs(keyphrase_length, base_keybert):
     """ Test extractino of protected multiple document method"""
     top_n = 5
     keywords_list = base_keybert._extract_keywords_multiple_docs([doc_one, doc_two],
                                                                  top_n=top_n,
-                                                                 keyphrase_length=keyphrase_length)
+                                                                 keyphrase_ngram_range=keyphrase_length)
     assert isinstance(keywords_list, list)
     assert isinstance(keywords_list[0], list)
     assert len(keywords_list) == 2
@@ -50,7 +59,7 @@ def test_extract_keywords_multiple_docs(keyphrase_length, base_keybert):
         assert len(keywords) == top_n
 
         for keyword in keywords:
-            assert len(keyword.split(" ")) == keyphrase_length
+            assert len(keyword.split(" ")) <= keyphrase_length[1]
 
 
 def test_error(base_keybert):


### PR DESCRIPTION
Adding `keyphrase_ngram_range` as parameter in `extract_keywords` (#13). Also gave users the possibility to use a custom `sklearn.feature_extraction.text.CountVectorizer` when creating candidates. 
