### PR TITLE
Fix out of bounds condition in mmr()

### DIFF
--- a/keybert/_mmr.py
+++ b/keybert/_mmr.py
@@ -39,7 +39,7 @@ def mmr(doc_embedding: np.ndarray,
     keywords_idx = [np.argmax(word_doc_similarity)]
     candidates_idx = [i for i in range(len(words)) if i != keywords_idx[0]]
 
-    for _ in range(top_n - 1):
+    for _ in range(min(top_n - 1, len(words) - 1)):
         # Extract similarities within candidates and
         # between candidates and selected keywords/phrases
         candidate_similarities = word_doc_similarity[candidates_idx, :]


### PR DESCRIPTION
`mmr()` fails when `top_n` > `len(words)`. This pull request fixes this.