### PR TITLE
fix(maxsum): Fix the way to specify the distance by index.

### DIFF
--- a/keybert/_maxsum.py
+++ b/keybert/_maxsum.py
@@ -51,4 +51,4 @@ def max_sum_similarity(doc_embedding: np.ndarray,
             candidate = combination
             min_sim = sim
 
-    return [(words_vals[idx], round(float(distances[0][idx]), 4)) for idx in candidate]
+    return [(words_vals[idx], round(float(distances[0][words_idx[idx]]), 4)) for idx in candidate]


### PR DESCRIPTION
Here are the changes to [this issue](https://github.com/MaartenGr/KeyBERT/issues/92) .