### PR TITLE
Cuda fix

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,11 @@ hide:
   - navigation
 ---
 
+## **Version 0.8.2**
+*Release date: 29 September, 2023*
+
+* Fixed cuda error when using pre-calculated embeddings with `KeyBERT` + `KeyLLM`
+
 ## **Version 0.8.1**
 *Release date: 29 September, 2023*
 

--- a/keybert/__init__.py
+++ b/keybert/__init__.py
@@ -1,4 +1,4 @@
 from keybert._llm import KeyLLM
 from keybert._model import KeyBERT
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/keybert/_model.py
+++ b/keybert/_model.py
@@ -255,14 +255,16 @@ class KeyBERT:
 
         # Fine-tune keywords using an LLM
         if self.llm is not None:
+            import torch
+            doc_embeddings = torch.from_numpy(doc_embeddings).float().to("cuda")
             if isinstance(all_keywords[0], tuple):
                 candidate_keywords = [[keyword[0] for keyword in all_keywords]]
             else:
                 candidate_keywords = [[keyword[0] for keyword in keywords] for keywords in all_keywords]
             keywords = self.llm.extract_keywords(
-                docs, 
+                docs,
                 embeddings=doc_embeddings,
-                candidate_keywords=candidate_keywords, 
+                candidate_keywords=candidate_keywords,
                 threshold=threshold
             )
             return keywords

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setup(
     name="keybert",
     packages=find_packages(exclude=["notebooks", "docs"]),
-    version="0.8.1",
+    version="0.8.2",
     author="Maarten Grootendorst",
     author_email="maartengrootendorst@gmail.com",
     description="KeyBERT performs keyword extraction with state-of-the-art transformer models.",


### PR DESCRIPTION
It seems that using pre-calculated embeddings throws an error since it expects embeddings to be a cuda tensor and not a numpy array. 