### PR TITLE
Cohere default model

### DIFF
--- a/keybert/llm/_cohere.py
+++ b/keybert/llm/_cohere.py
@@ -82,7 +82,7 @@ class Cohere(BaseLLM):
     """
     def __init__(self,
                  client,
-                 model: str = "xlarge",
+                 model: str = "command",
                  prompt: str = None,
                  delay_in_seconds: float = None,
                  verbose: bool = False


### PR DESCRIPTION
Updating default model to "command" from "xLarge" for cohere 