### PR TITLE
Use MMR as the output score and sorting key

### DIFF
--- a/keybert/_mmr.py
+++ b/keybert/_mmr.py
@@ -41,6 +41,7 @@ def mmr(
     # Initialize candidates and already choose best keyword/keyphras
     keywords_idx = [np.argmax(word_doc_similarity)]
     candidates_idx = [i for i in range(len(words)) if i != keywords_idx[0]]
+    words_mmr = [(1 - diversity) * np.max(word_doc_similarity)]
 
     for _ in range(min(top_n - 1, len(words) - 1)):
         # Extract similarities within candidates and
@@ -55,15 +56,14 @@ def mmr(
             1 - diversity
         ) * candidate_similarities - diversity * target_similarities.reshape(-1, 1)
         mmr_idx = candidates_idx[np.argmax(mmr)]
+        words_mmr.append(np.max(mmr))
 
         # Update keywords & candidates
         keywords_idx.append(mmr_idx)
         candidates_idx.remove(mmr_idx)
 
     # Extract and sort keywords in descending similarity
-    keywords = [
-        (words[idx], round(float(word_doc_similarity.reshape(1, -1)[0][idx]), 4))
-        for idx in keywords_idx
-    ]
+    keywords = [(words[keywords_idx[i]], round(float(words_mmr[i]), 4))
+                for i in range(len(keywords_idx))]
     keywords = sorted(keywords, key=itemgetter(1), reverse=True)
     return keywords


### PR DESCRIPTION
When consider using [Maximal Marginal Relevance (MMR)](https://github.com/MaartenGr/KeyBERT?tab=readme-ov-file#24-maximal-marginal-relevance) to diversify the results it turns out the keyword or keyphrases order are based on the cosine similarity scores instead of the MMR. Although the same keywords are returned, I would expect to see more diversity in the top results. 

```
from keybert import KeyBERT

doc = """
         Supervised learning is the machine learning task of learning a function that
         maps an input to an output based on example input-output pairs. It infers a
         function from labeled training data consisting of a set of training examples.
         In supervised learning, each example is a pair consisting of an input object
         (typically a vector) and a desired output value (also called the supervisory signal).
         A supervised learning algorithm analyzes the training data and produces an inferred function,
         which can be used for mapping new examples. An optimal scenario will allow for the
         algorithm to correctly determine the class labels for unseen instances. This requires
         the learning algorithm to generalize from the training data to unseen situations in a
         'reasonable' way (see inductive bias).
      """
kw_model = KeyBERT()
keywords = kw_model.extract_keywords(doc)
```

Current output
```
>>> kw_model.extract_keywords(doc, keyphrase_ngram_range=(3, 3), stop_words='english', use_mmr=True, diversity=0.2)
[('supervised learning algorithm', 0.6992),
 ('supervised learning example', 0.6807),
 ('supervised learning machine', 0.6706),
 ('function labeled training', 0.663),
 ('supervisory signal supervised', 0.5802)]
```

Expected output (here the scores are the MRR)
```
>>> kw_model.extract_keywords(doc, keyphrase_ngram_range=(3, 3), stop_words='english', use_mmr=True, diversity=0.2)
[('supervised learning algorithm', 0.5594),
 ('function labeled training', 0.4173),
 ('supervised learning example', 0.3902),
 ('supervisory signal supervised', 0.3673),
 ('supervised learning machine', 0.362)]
```
