### PR TITLE
Update _model.py

### DIFF
--- a/keybert/_model.py
+++ b/keybert/_model.py
@@ -258,7 +258,8 @@ class KeyBERT:
         if len(all_keywords) == 1:
             if highlight:
                 highlight_document(docs[0], all_keywords[0], count)
-            all_keywords = all_keywords[0]
+            # Remove this line to maintain list of lists structure even when a list is passed with single element
+            # all_keywords = all_keywords[0]
 
         # Fine-tune keywords using an LLM
         if self.llm is not None:


### PR DESCRIPTION
this extract_keywords function is returning a list of lists when a list of multiple elements are passed , but when a list of only one element is passed, it is not returning a list of lists as it should. it is acting as if a string is passed. 

I can see the issue. The inconsistency happens in the code where it handles the single document case. Let's fix this by modifying the code to maintain consistent return types. Here's the correction: The issue was in the section where it handles a single document case. The line all_keywords = all_keywords[0] was flattening the list structure when there was only one document. By removing this line, we maintain the consistent list of lists structure regardless of whether we have one or multiple documents. This change means:
For multiple documents: [[kw1, kw2], [kw3, kw4]] (unchanged) For single document: [[kw1, kw2]] (now consistent, instead of [kw1, kw2])