### PR TITLE
Remove dependency on deprecated langchain apis

### DIFF
--- a/docs/guides/llms.md
+++ b/docs/guides/llms.md
@@ -172,32 +172,43 @@ kw_model = KeyLLM(llm)
 
 ### **LangChain**
 
-To use LangChain, we can simply load in any LLM and pass that as a QA-chain to KeyLLM.
+To use `langchain` LLM client in KeyLLM, we can simply load in any LLM in `langchain` and pass that to KeyLLM.
 
-We install the package first:
+We install langchain and corresponding LLM provider package first. Take OpenAI as an example:
 
 ```bash
 pip install langchain
+pip install langchain-openai # LLM provider package
 ```
+> [!NOTE] 
+> KeyBERT only supports `langchain >= 0.1`
 
-Then we run LangChain as follows:
+
+Then create your LLM client with `langchain`
 
 
 ```python
-from langchain.chains.question_answering import load_qa_chain
-from langchain.llms import OpenAI
-chain = load_qa_chain(OpenAI(temperature=0, openai_api_key=my_openai_api_key), chain_type="stuff")
+from langchain_openai import ChatOpenAI
+
+_llm = ChatOpenAI(
+    model="gpt-4o",
+    api_key="my-openai-api-key",
+    temperature=0,
+)
 ```
 
-Finally, you can pass the chain to KeyBERT as follows:
+Finally, pass the `langchain` llm client to KeyBERT as follows:
 
 ```python
 from keybert.llm import LangChain
 from keybert import KeyLLM
 
 # Create your LLM
-llm = LangChain(chain)
+llm = LangChain(_llm)
 
 # Load it in KeyLLM
 kw_model = KeyLLM(llm)
+
+# Extract keywords
+keywords = kw_model.extract_keywords(MY_DOCUMENTS)
 ```

--- a/docs/guides/llms.md
+++ b/docs/guides/llms.md
@@ -180,7 +180,7 @@ We install langchain and corresponding LLM provider package first. Take OpenAI a
 pip install langchain
 pip install langchain-openai # LLM provider package
 ```
-> [!NOTE] 
+> [!NOTE]
 > KeyBERT only supports `langchain >= 0.1`
 
 

--- a/keybert/llm/__init__.py
+++ b/keybert/llm/__init__.py
@@ -1,3 +1,5 @@
+from packaging.version import InvalidVersion
+
 from keybert._utils import NotInstalled
 from keybert.llm._base import BaseLLM
 
@@ -34,6 +36,9 @@ try:
     from keybert.llm._langchain import LangChain
 except ModuleNotFoundError:
     msg = "`pip install langchain` \n\n"
+    LangChain = NotInstalled("langchain", "langchain", custom_msg=msg)
+except InvalidVersion as e:
+    msg = f"`pip install -U langchain` \n\nsince {e}\n\n"
     LangChain = NotInstalled("langchain", "langchain", custom_msg=msg)
 
 # LiteLLM

--- a/keybert/llm/__init__.py
+++ b/keybert/llm/__init__.py
@@ -32,12 +32,19 @@ except ModuleNotFoundError:
 # LangChain Generator
 try:
     from keybert.llm._langchain import LangChain
-except ModuleNotFoundError:
-    msg = "`pip install langchain` \n\n"
-    LangChain = NotInstalled("langchain", "langchain", custom_msg=msg)
-except ImportError as e:
-    msg = f"`pip install -U langchain` \n\nsince {e}\n\n"
-    LangChain = NotInstalled("langchain", "langchain", custom_msg=msg)
+except ModuleNotFoundError as e:
+    match e.name:
+        case "langchain":
+            msg = "`pip install langchain` \n\n"
+            LangChain = NotInstalled("langchain", "langchain", custom_msg=msg)
+        case "langchain_core":
+            msg = "`pip install -U langchain` to upgrade to langchain>=0.1\n\n"
+            LangChain = NotInstalled("langchain", "langchain", custom_msg=msg)
+        case _:
+            raise e
+# except ImportError as e:
+#     msg = f"`pip install -U langchain` \n\nsince {e}\n\n"
+#     LangChain = NotInstalled("langchain", "langchain", custom_msg=msg)
 
 # LiteLLM
 try:

--- a/keybert/llm/__init__.py
+++ b/keybert/llm/__init__.py
@@ -33,18 +33,15 @@ except ModuleNotFoundError:
 try:
     from keybert.llm._langchain import LangChain
 except ModuleNotFoundError as e:
-    match e.name:
-        case "langchain":
-            msg = "`pip install langchain` \n\n"
-            LangChain = NotInstalled("langchain", "langchain", custom_msg=msg)
-        case "langchain_core":
-            msg = "`pip install -U langchain` to upgrade to langchain>=0.1\n\n"
-            LangChain = NotInstalled("langchain", "langchain", custom_msg=msg)
-        case _:
-            raise e
-# except ImportError as e:
-#     msg = f"`pip install -U langchain` \n\nsince {e}\n\n"
-#     LangChain = NotInstalled("langchain", "langchain", custom_msg=msg)
+    if e.name == "langchain":
+        msg = "`pip install langchain` \n\n"
+        LangChain = NotInstalled("langchain", "langchain", custom_msg=msg)
+    elif e.name == "langchain_core":
+        msg = "`pip install -U langchain` to upgrade to langchain>=0.1\n\n"
+        LangChain = NotInstalled("langchain", "langchain", custom_msg=msg)
+    else:
+        # not caused by importing langchain or langchain_core
+        raise e
 
 # LiteLLM
 try:

--- a/keybert/llm/__init__.py
+++ b/keybert/llm/__init__.py
@@ -1,5 +1,3 @@
-from packaging.version import InvalidVersion
-
 from keybert._utils import NotInstalled
 from keybert.llm._base import BaseLLM
 
@@ -37,7 +35,7 @@ try:
 except ModuleNotFoundError:
     msg = "`pip install langchain` \n\n"
     LangChain = NotInstalled("langchain", "langchain", custom_msg=msg)
-except InvalidVersion as e:
+except ImportError as e:
     msg = f"`pip install -U langchain` \n\nsince {e}\n\n"
     LangChain = NotInstalled("langchain", "langchain", custom_msg=msg)
 

--- a/keybert/llm/_langchain.py
+++ b/keybert/llm/_langchain.py
@@ -47,7 +47,7 @@ class LangChain(BaseLLM):
     Then, you can create your chain as follows:
 
     ```python
-    from langchain.prompts import PromptTemplate
+    from langchain.prompts import ChatPromptTemplate
     from langchain_core.output_parsers import StrOutputParser
     from langchain_openai import ChatOpenAI
     _llm = ChatOpenAI(
@@ -55,7 +55,11 @@ class LangChain(BaseLLM):
         api_key="my-openai-api-key",
         temperature=0,
     )
-    _prompt = PromptTemplate.from_template(LangChain.DEFAULT_PROMPT_TEMPLATE)  # the default prompt from KeyBERT
+    _prompt = ChatPromptTemplate(
+        [
+            ("human", LangChain.DEFAULT_PROMPT_TEMPLATE),  # the default prompt from KeyBERT
+        ]
+    )
     chain = _prompt | _llm | StrOutputParser()
     ```
 

--- a/keybert/llm/_langchain.py
+++ b/keybert/llm/_langchain.py
@@ -22,10 +22,10 @@ class LangChain(BaseLLM):
         llm: A langchain LLM class. e.g ChatOpenAI, OpenAI, etc.
         prompt: The prompt to be used in the model. If no prompt is given,
                 `self.DEFAULT_PROMPT_TEMPLATE` is used instead.
-                NOTE:
+                THe prompt should contain:
                 1. Placeholders
-                - [DOCUMENT]: Required. The document to extract keywords from.
-                - [CANDIDATES]: Optional. The candidate keywords to fine-tune the extraction.
+                - `[DOCUMENT]`: Required. The document to extract keywords from.
+                - `[CANDIDATES]`: Optional. The candidate keywords to fine-tune the extraction.
                 2. Output format instructions
                 - The resulting keywords are expected to a list of comma-sparated str so ensure the foramt in your prompt.
                     e.g. "The output must be a list of comma separated keywords."

--- a/keybert/llm/_langchain.py
+++ b/keybert/llm/_langchain.py
@@ -1,20 +1,9 @@
 from typing import List
 
-from packaging.version import Version
-
-try:
-    import langchain
-    from langchain.prompts import ChatPromptTemplate, PromptTemplate
-    from langchain_core.language_models.chat_models import BaseChatModel as LangChainBaseChatModel
-    from langchain_core.language_models.llms import BaseLLM as LangChainBaseLLM
-    from langchain_core.output_parsers import StrOutputParser
-
-    assert Version(langchain.__version__) >= Version("0.1")
-except ImportError as e:
-    raise ImportError("LangChain is not installed. Please install it using `pip install langchain`.") from e
-except AssertionError:
-    raise ImportError("LangChain version >= 0.1 is required. Please update it using `pip install --upgrade langchain`.")
-
+from langchain.prompts import ChatPromptTemplate, PromptTemplate
+from langchain_core.language_models.chat_models import BaseChatModel as LangChainBaseChatModel
+from langchain_core.language_models.llms import BaseLLM as LangChainBaseLLM
+from langchain_core.output_parsers import StrOutputParser
 from tqdm import tqdm
 
 from keybert.llm._base import BaseLLM

--- a/keybert/llm/_langchain.py
+++ b/keybert/llm/_langchain.py
@@ -28,7 +28,7 @@ class LangChain(BaseLLM):
                 - `[DOCUMENT]`: Required. The document to extract keywords from.
                 - `[CANDIDATES]`: Optional. The candidate keywords to fine-tune the extraction.
                 2. Output format instructions
-                - Include this or somethign similar in your prompt:
+                - Include this or something similar in your prompt:
                     "Extracted keywords must be separated by comma."
         verbose: Set this to True if you want to see a progress bar for the
                 keyword extraction.

--- a/keybert/llm/_langchain.py
+++ b/keybert/llm/_langchain.py
@@ -1,8 +1,8 @@
 from typing import List
 
 from langchain.prompts import ChatPromptTemplate, PromptTemplate
-from langchain_core.language_models.chat_models import BaseChatModel as LCChatModel
-from langchain_core.language_models.llms import BaseLLM as LCBaseLLM
+from langchain_core.language_models.chat_models import BaseChatModel as LangChainBaseChatModel
+from langchain_core.language_models.llms import BaseLLM as LangChainBaseLLM
 from langchain_core.output_parsers import StrOutputParser
 from tqdm import tqdm
 
@@ -126,7 +126,7 @@ For example: "keyword1, keyword2, keyword3"
 
     def __init__(
         self,
-        llm: LCChatModel | LCBaseLLM,
+        llm: LangChainBaseChatModel | LangChainBaseLLM,
         prompt: str = None,
         verbose: bool = False,
     ):
@@ -162,10 +162,9 @@ For example: "keyword1, keyword2, keyword3"
         """Get the chain using LLM and prompt."""
         # format prompt for langchain template placeholders
         prompt = self.prompt.replace("[DOCUMENT]", "{DOCUMENT}").replace("[CANDIDATES]", "{CANDIDATES}")
-
+        # check if the model is a chat model
+        is_chat_model = isinstance(self.llm, LangChainBaseChatModel)
         # langchain prompt template
-        is_chat_model = isinstance(self.llm, LCChatModel)
         prompt_template = ChatPromptTemplate([("human", prompt)]) if is_chat_model else PromptTemplate(template=prompt)
-
         # chain
         return prompt_template | self.llm | StrOutputParser()

--- a/keybert/llm/_langchain.py
+++ b/keybert/llm/_langchain.py
@@ -18,9 +18,6 @@ from keybert.llm._utils import process_candidate_keywords
 class LangChain(BaseLLM):
     """Using chains in langchain to generate keywords.
 
-
-
-
     Arguments:
         llm: A langchain LLM class. e.g ChatOpenAI, OpenAI, etc.
         prompt: The prompt to be used in the model. If no prompt is given,

--- a/keybert/llm/_langchain.py
+++ b/keybert/llm/_langchain.py
@@ -1,13 +1,18 @@
 from typing import List
 
+import langchain
 from langchain.prompts import ChatPromptTemplate, PromptTemplate
 from langchain_core.language_models.chat_models import BaseChatModel as LangChainBaseChatModel
 from langchain_core.language_models.llms import BaseLLM as LangChainBaseLLM
 from langchain_core.output_parsers import StrOutputParser
+from packaging.version import InvalidVersion, Version
 from tqdm import tqdm
 
 from keybert.llm._base import BaseLLM
 from keybert.llm._utils import process_candidate_keywords
+
+if Version(langchain.__version__) < Version("0.1"):
+    raise InvalidVersion("langchain>=0.1 is required.")
 
 """NOTE
 KeyBERT only supports `langchain >= 0.1` which features:

--- a/keybert/llm/_langchain.py
+++ b/keybert/llm/_langchain.py
@@ -28,9 +28,8 @@ class LangChain(BaseLLM):
                 - `[DOCUMENT]`: Required. The document to extract keywords from.
                 - `[CANDIDATES]`: Optional. The candidate keywords to fine-tune the extraction.
                 2. Output format instructions
-                - The prompt must include the output format instruction
-                    that extracted keywords should be sparated by comma.
-                    e.g. "The output must be a list of comma separated keywords."
+                - Include this or somethign similar in your prompt:
+                    "Extracted keywords must be separated by comma."
         verbose: Set this to True if you want to see a progress bar for the
                 keyword extraction.
 

--- a/keybert/llm/_langchain.py
+++ b/keybert/llm/_langchain.py
@@ -19,7 +19,7 @@ Use the candidate keywords to guide your extraction.
 
 
 Now extract the keywords from the document.
-Your output must be a list of comma-separated keywords.
+The keywords must be comma separated .
 """
 
 
@@ -55,8 +55,8 @@ class LangChain(BaseLLM):
         api_key="my-openai-api-key",
         temperature=0,
     )
-    _prompt = PromptTemplate.from_template(LangChain.DEFAULT_PROMPT_TEMPLATE) # the default prompt from KeyBERT
-    chain = _prompt | _llm
+    _prompt = PromptTemplate.from_template(LangChain.DEFAULT_PROMPT_TEMPLATE)  # the default prompt from KeyBERT
+    chain = _prompt | _llm | StrOutputParser()
     ```
 
     Finally, you can pass the chain to KeyBERT as follows:
@@ -71,9 +71,18 @@ class LangChain(BaseLLM):
     # Load it in KeyLLM
     kw_model = KeyLLM(llm)
 
-    document = "The website mentions that it only takes a couple of days to deliver but I still have not received mine."
-    candidates = ["days", "website", "deliver", "received"]
-    keywords = kw_model.extract_keywords(document)
+    # Extract keywords
+    docs = [
+        "KeyBERT: A minimal method for keyword extraction with BERT. The keyword extraction is done by finding the sub-phrases in a document that are the most similar to the document itself. First, document embeddings are extracted with BERT to get a document-level representation. Then, word embeddings are extracted for N-gram words/phrases. Finally, we use cosine similarity to find the words/phrases that are the most similar to the document. The most similar words could then be identified as the words that best describe the entire document.",
+        "KeyLLM: A minimal method for keyword extraction with Large Language Models (LLM). The keyword extraction is done by simply asking the LLM to extract a number of keywords from a single piece of text.",
+    ]
+    candidates = [
+        ["keyword extraction", "Large Language Models", "LLM", "BERT", "transformer", "embeddings"],
+        ["keyword extraction", "Large Language Models", "LLM", "BERT", "transformer", "embeddings"],
+    ]
+    keywords = kw_model.extract_keywords(docs=docs, candidate_keywords=candidates)
+    print(keywords)
+    # [['keyword extraction', 'BERT', 'embeddings'], ['keyword extraction', 'Large Language Models', 'LLM']]
     ```
 
     You can also use a custom prompt:

--- a/keybert/llm/_langchain.py
+++ b/keybert/llm/_langchain.py
@@ -12,7 +12,7 @@ from keybert.llm._base import BaseLLM
 from keybert.llm._utils import process_candidate_keywords
 
 if Version(langchain.__version__) < Version("0.1"):
-    raise InvalidVersion("langchain>=0.1 is required.")
+    raise InvalidVersion(f"langchain>=0.1 is required, but langchain=={langchain.__version__} is installed.")
 
 """NOTE
 KeyBERT only supports `langchain >= 0.1` which features:

--- a/keybert/llm/_langchain.py
+++ b/keybert/llm/_langchain.py
@@ -129,20 +129,22 @@ The keywords must be comma separated.
     ):
         self.llm = llm
         self.prompt = prompt if prompt is not None else self.DEFAULT_PROMPT_TEMPLATE
+        self.verbose = verbose
+
         # format prompt for langchain template placeholders
         self.prompt = self.prompt.replace("[DOCUMENT]", "{DOCUMENT}").replace("[CANDIDATES]", "{CANDIDATES}")
-
+        # llm type check
         assert isinstance(llm, (LCChatModel, LCBaseLLM)), (
             "A LangChain LLM must be either a chat model or a completion model."
         )
+        # langchain prompt template
         prompt_template = (
             ChatPromptTemplate([("human", self.prompt)])
             if isinstance(llm, LCChatModel)
             else PromptTemplate(template=self.prompt)
         )
+        # chain
         self.chain = prompt_template | llm | CommaSeparatedListOutputParser()
-
-        self.verbose = verbose
 
     def extract_keywords(self, documents: List[str], candidate_keywords: List[List[str]] = None):
         """Extract topics.

--- a/keybert/llm/_langchain.py
+++ b/keybert/llm/_langchain.py
@@ -1,6 +1,5 @@
 from typing import List
 
-import langchain
 from langchain.prompts import ChatPromptTemplate, PromptTemplate
 from langchain_core.language_models.chat_models import BaseChatModel as LangChainBaseChatModel
 from langchain_core.language_models.llms import BaseLLM as LangChainBaseLLM
@@ -9,9 +8,6 @@ from tqdm import tqdm
 
 from keybert.llm._base import BaseLLM
 from keybert.llm._utils import process_candidate_keywords
-
-if langchain.__version__ < "0.1":  # for more complicated version comparison, use packaging.version
-    raise ImportError(f"langchain>=0.1 is required, but {langchain.__version__} is installed.")
 
 """NOTE
 KeyBERT only supports `langchain >= 0.1` which features:

--- a/keybert/llm/_langchain.py
+++ b/keybert/llm/_langchain.py
@@ -1,18 +1,27 @@
 from typing import List
 
-from langchain.prompts import ChatPromptTemplate, PromptTemplate
-from langchain_core.language_models.chat_models import BaseChatModel as LangChainBaseChatModel
-from langchain_core.language_models.llms import BaseLLM as LangChainBaseLLM
-from langchain_core.output_parsers import StrOutputParser
+try:
+    import langchain
+    from langchain.prompts import ChatPromptTemplate, PromptTemplate
+    from langchain_core.language_models.chat_models import BaseChatModel as LangChainBaseChatModel
+    from langchain_core.language_models.llms import BaseLLM as LangChainBaseLLM
+    from langchain_core.output_parsers import StrOutputParser
+
+    assert langchain.__version__ >= "0.1"
+except ImportError as e:
+    raise ImportError("LangChain is not installed. Please install it using `pip install langchain`.") from e
+except AssertionError:
+    raise ImportError("LangChain version >= 0.1 is required. Please update it using `pip install --upgrade langchain`.")
+
 from tqdm import tqdm
 
 from keybert.llm._base import BaseLLM
 from keybert.llm._utils import process_candidate_keywords
 
 """NOTE
-langchain >= 0.1 is required. Which supports:
-- chain.invoke()
-- LangChain Expression Language (LCEL) is used and it is not compatible with langchain < 0.1.
+KeyBERT only supports `langchain >= 0.1` which features:
+- [Runnable Interface](https://python.langchain.com/docs/concepts/runnables/)
+- [LangChain Expression Language (LCEL)](https://python.langchain.com/docs/concepts/lcel/)
 """
 
 

--- a/keybert/llm/_langchain.py
+++ b/keybert/llm/_langchain.py
@@ -50,6 +50,9 @@ class LangChain(BaseLLM):
     from langchain.prompts import ChatPromptTemplate
     from langchain_core.output_parsers import StrOutputParser
     from langchain_openai import ChatOpenAI
+
+    from keybert.llm import LangChain
+
     _llm = ChatOpenAI(
         model="gpt-4o",
         api_key="my-openai-api-key",

--- a/keybert/llm/_langchain.py
+++ b/keybert/llm/_langchain.py
@@ -129,17 +129,18 @@ The keywords must be comma separated.
     ):
         self.llm = llm
         self.prompt = prompt if prompt is not None else self.DEFAULT_PROMPT_TEMPLATE
-        # format for langchain template placeholders
+        # format prompt for langchain template placeholders
         self.prompt = self.prompt.replace("[DOCUMENT]", "{DOCUMENT}").replace("[CANDIDATES]", "{CANDIDATES}")
 
-        if isinstance(llm, LCChatModel):
-            # a chat model (modern ones)
-            self.chain = ChatPromptTemplate([("human", self.prompt)]) | llm | CommaSeparatedListOutputParser()
-        elif isinstance(llm, LCBaseLLM):
-            # a completion model (usually legacy)
-            self.chain = PromptTemplate(template=self.prompt) | llm | CommaSeparatedListOutputParser()
-        else:
-            raise ValueError("A LangChain LLM must be either a chat model or a completion model.")
+        assert isinstance(llm, (LCChatModel, LCBaseLLM)), (
+            "A LangChain LLM must be either a chat model or a completion model."
+        )
+        prompt_template = (
+            ChatPromptTemplate([("human", self.prompt)])
+            if isinstance(llm, LCChatModel)
+            else PromptTemplate(template=self.prompt)
+        )
+        self.chain = prompt_template | llm | CommaSeparatedListOutputParser()
 
         self.verbose = verbose
 

--- a/keybert/llm/_langchain.py
+++ b/keybert/llm/_langchain.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from packaging.version import Version
+
 try:
     import langchain
     from langchain.prompts import ChatPromptTemplate, PromptTemplate
@@ -7,7 +9,7 @@ try:
     from langchain_core.language_models.llms import BaseLLM as LangChainBaseLLM
     from langchain_core.output_parsers import StrOutputParser
 
-    assert langchain.__version__ >= "0.1"
+    assert Version(langchain.__version__) >= Version("0.1")
 except ImportError as e:
     raise ImportError("LangChain is not installed. Please install it using `pip install langchain`.") from e
 except AssertionError:

--- a/keybert/llm/_langchain.py
+++ b/keybert/llm/_langchain.py
@@ -5,14 +5,13 @@ from langchain.prompts import ChatPromptTemplate, PromptTemplate
 from langchain_core.language_models.chat_models import BaseChatModel as LangChainBaseChatModel
 from langchain_core.language_models.llms import BaseLLM as LangChainBaseLLM
 from langchain_core.output_parsers import StrOutputParser
-from packaging.version import InvalidVersion, Version
 from tqdm import tqdm
 
 from keybert.llm._base import BaseLLM
 from keybert.llm._utils import process_candidate_keywords
 
-if Version(langchain.__version__) < Version("0.1"):
-    raise InvalidVersion(f"langchain>=0.1 is required, but langchain=={langchain.__version__} is installed.")
+if langchain.__version__ < "0.1":  # for more complicated version comparison, use packaging.version
+    raise ImportError(f"langchain>=0.1 is required, but {langchain.__version__} is installed.")
 
 """NOTE
 KeyBERT only supports `langchain >= 0.1` which features:


### PR DESCRIPTION
Issue: #259

Description:

- [x] replace deprecated lagnchain api `.run()` with `.invoke()`
- [x] replace deprecated `load_qa_chain` with a simple chain of langchain
- [x] a new default prompt 
- [x] update docstring for documentation use


I did not add a test for this change, since I don't see langchain installed in KeyBERT test env, so posted the test below (Same as in the `keybert.llm.LangChain` docsting)

New user experience, also how to test this change 

```python
from langchain.prompts import ChatPromptTemplate
from langchain_core.output_parsers import StrOutputParser
from langchain_openai import ChatOpenAI

from keybert import KeyLLM
from keybert.llm import LangChain

_llm = ChatOpenAI(
    model="gpt-4o",
    api_key="my-openai-api-key",
    temperature=0,
)
_prompt = ChatPromptTemplate(
    [
        ("human", LangChain.DEFAULT_PROMPT_TEMPLATE),  # the default prompt from KeyBERT
    ]
)
chain = _prompt | _llm | StrOutputParser()


# Create your LLM
llm = LangChain(chain)

# Load it in KeyLLM
kw_model = KeyLLM(llm)

# Extract keywords
docs = [
    "KeyBERT: A minimal method for keyword extraction with BERT. The keyword extraction is done by finding the sub-phrases in a document that are the most similar to the document itself. First, document embeddings are extracted with BERT to get a document-level representation. Then, word embeddings are extracted for N-gram words/phrases. Finally, we use cosine similarity to find the words/phrases that are the most similar to the document. The most similar words could then be identified as the words that best describe the entire document.",
    "KeyLLM: A minimal method for keyword extraction with Large Language Models (LLM). The keyword extraction is done by simply asking the LLM to extract a number of keywords from a single piece of text.",
]
candidates = [
    ["keyword extraction", "Large Language Models", "LLM", "BERT", "transformer", "embeddings"],
    ["keyword extraction", "Large Language Models", "LLM", "BERT", "transformer", "embeddings"],
]
keywords = kw_model.extract_keywords(docs=docs, candidate_keywords=candidates)
print(keywords)
# [['keyword extraction', 'BERT', 'embeddings'], ['keyword extraction', 'Large Language Models', 'LLM']]

```

# Discussion
@MaartenGr Please review these concerns below. 

- While implementing this PR, I feel it a bit hard to identify what keybert wants to provide on top of langchain, so please review if the new user experience above makes sense. My understanding is that 
  - `keybert.llm.LangChain` provides
    - a default prompt template that nicely extract keywords from a doc using candidate keywords
    - keywords output parsed as list[str] such that can be integrated with KeyLLM
  - I am assuming that users have basic understanding of writing simple langchain chain below since they choose to use langchain with keybert.
  - I am assume the motivation of `keybert.llm.LangChain` is to support a chain, not a LLM model. 
However, a chain can be so flexible, containing prompts, llm, output formats / parsers, etc, that it is very tricky trying to change the prompt template of a given chain inside our own `keybert.llm.LangChain` by taking a prompt arg. So in this PR, I am suggesting users to use `LangChain.DEFAULT_PROMPT_TEMPLATE` when they create the chain. And prompt arg is removed from `keybert.llm.LangChain.__init__`.

- I see `keybert.llm.LangChain` imports langchain in source code [this line](https://github.com/MaartenGr/KeyBERT/blob/master/keybert/llm/_langchain.py#L3), but does not list it as a dependency in `pyproject.toml`. Are we assuming before` keybert.llm.LangChain` is called, user must have installed langchain since they have to write their only chain?