### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,12 +12,14 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-    # Ref: https://github.com/pre-commit/action
-    - uses: pre-commit/action@v3.0.1
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      with:
+        python-version: "3.13"
+    # Ref: https://github.com/tox-dev/action-pre-commit-uv
+    - uses: tox-dev/action-pre-commit-uv@246b66536e366bb885f52d61983bf32f7c95e8b1 # v1.0.3
 
   build:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.0
+    rev: v0.15.4
     hooks:
     -   id: ruff-check
         args: [--fix, --show-fixes, --exit-non-zero-on-fix]


### PR DESCRIPTION
Hi, this PR updates the configured pre-commit hooks.

I also added the switch to the tox-dev/action-pre-commit-uv action, as done in `BERTopic`: 
https://github.com/MaartenGr/BERTopic/blob/b2ce08422250111aedce5019b63c062016f9d109/.github/workflows/testing.yml#L22

In this step i also bumped the other actions of the lint job. I hope this okay all in one PR.

I just recently realized, that there is a `ubunu-slim` image, which is suitable to run smaller jobs, like the linter. This helps save some resources, as this job does not need Docker services, databases and so on.

What do you think?