### PR TITLE
chore: remove obsolete test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,6 @@ spacy = [
     "spacy>=3.0.1",
 ]
 test = [
-    "black>=19.3b0",
-    "flake8>=3.6.0",
     "pre-commit>=2.2.0",
     "pytest-cov>=2.6.1",
     "pytest>=5.4.3",


### PR DESCRIPTION
black and flake8 are not used anymore? So they can be removed from test dependencies.